### PR TITLE
test/unit_type: add test to show that unit types work

### DIFF
--- a/front/src/syntax/parser.rs
+++ b/front/src/syntax/parser.rs
@@ -891,6 +891,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_unit_expression() {
+        let expr = parse_expr("{}");
+        let ast::Expression::Block(comp) = expr else {
+            panic!("Unit type should be treated like a literal");
+        };
+
+        // Since the last expression is none, this will have unit return type.
+        // A little different than other languages that use (), this is because
+        // right now, ( must be followed by an expression, then ), this can be
+        // revisited later, not a big deal
+        assert!(comp.final_expr.is_none());
+    }
+
+    #[test]
     fn parses_field_access_after_application() {
         let expr = parse_expr("foo \"hello\".name");
 

--- a/testing/basic_tests/orandxor/info.toml
+++ b/testing/basic_tests/orandxor/info.toml
@@ -1,0 +1,7 @@
+[test]
+name = "andorxor"
+description = "Many and, or, and xor operations"
+
+parser = "pass"
+mir = "pass"
+vm = "pass"

--- a/testing/basic_tests/types/info.toml
+++ b/testing/basic_tests/types/info.toml
@@ -1,0 +1,7 @@
+[test]
+name = "Basic types"
+description = "A basic program that assigns the basic types to make sure there is nothing weird going on"
+
+parser = "pass"
+mir = "pass"
+vm = "pass"

--- a/testing/basic_tests/types/main.cm
+++ b/testing/basic_tests/types/main.cm
@@ -1,0 +1,10 @@
+typ main :: Int
+def main = {
+	-- Call a function with Unit as the input
+	def bar :: Int = foo {};
+	def str :: String = "hello!";
+	2
+}
+
+typ foo :: Unit -> Int
+def foo _ = 2

--- a/vm/src/lower.rs
+++ b/vm/src/lower.rs
@@ -81,7 +81,8 @@ impl<'a> Lowerer<'a> {
                         }];
                         return Ok(v);
                     }
-                    ir::Consts::Unit => return Err(VError::UnsupportedConstant),
+                    // For unit types, we just do nothing.
+                    ir::Consts::Unit => return Ok(vec![]),
                 };
                 Ok(vec![Bytecode::Const {
                     dst: destination,


### PR DESCRIPTION
They are a little different than other languages for now, since we use {} rather than () for unit, so lets just document that quirk in the code with tests, and re-visit it later if we want to.